### PR TITLE
c-kzg experiments/benchmark

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -26,7 +26,7 @@ libckzg.a: $(LIB_OBJ) Makefile
 	clang -Wall -DKZGTEST -DDEBUG -I$(INCLUDE_DIRS) $(CFLAGS) $(KZG_CFLAGS) -o $@ $*.c debug_util.o test_util.o libckzg.a -L../lib -lblst
 
 # Benchmarks
-%_bench: KZG_CFLAGS += -O
+%_bench: KZG_CFLAGS += -O3
 %_bench: %_bench.c bench_util.o test_util.o libckzg.a Makefile
 	clang -Wall -I$(INCLUDE_DIRS) $(CFLAGS) $(KZG_CFLAGS) -o $@ $@.c bench_util.o test_util.o libckzg.a -L../lib -lblst
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -29,7 +29,6 @@ libckzg.a: $(LIB_OBJ) Makefile
 %_bench: KZG_CFLAGS += -O
 %_bench: %_bench.c bench_util.o test_util.o libckzg.a Makefile
 	clang -Wall -I$(INCLUDE_DIRS) $(CFLAGS) $(KZG_CFLAGS) -o $@ $@.c bench_util.o test_util.o libckzg.a -L../lib -lblst
-	./$@
 
 # Tuning
 %_tune: KZG_CFLAGS += -O

--- a/src/bench_util.c
+++ b/src/bench_util.c
@@ -19,3 +19,12 @@
 unsigned long tdiff(timespec_t start, timespec_t end) {
     return (end.tv_sec - start.tv_sec) * NANO + (end.tv_nsec - start.tv_nsec);
 }
+
+unsigned long tdiff_usec(timespec_t start, timespec_t end) {
+    long nsec = (end.tv_sec - start.tv_sec) * NANO + (end.tv_nsec - start.tv_nsec);
+    if (nsec < 1000) {
+        return 1;
+    } else {
+        return nsec / 1000;
+    }
+}

--- a/src/bench_util.h
+++ b/src/bench_util.h
@@ -22,3 +22,7 @@ typedef struct timespec timespec_t;
 #define NSEC 1
 
 unsigned long tdiff(timespec_t start, timespec_t end);
+unsigned long tdiff_usec(timespec_t start, timespec_t end);
+
+
+

--- a/src/bls12_381.c
+++ b/src/bls12_381.c
@@ -397,10 +397,11 @@ void g2_dbl(g2_t *out, const g2_t *a) {
  *
  * Calculates `[coeffs_0]p_0 + [coeffs_1]p_1 + ... + [coeffs_n]p_n` where `n` is `len - 1`.
  *
- * @param[out] out    The resulting sum-product
- * @param[in]  p      Array of G1 group elements, length @p len
- * @param[in]  coeffs Array of field elements, length @p len
- * @param[in]  len    The number of group/field elements
+ * @param[out] out       The resulting sum-product
+ * @param[in]  p         Array of G1 group elements, length @p len
+ * @param[in]  p_affine  Array of G1 group elements in affine format, length @p len
+ * @param[in]  coeffs    Array of field elements, length @p len
+ * @param[in]  len       The number of group/field elements
  *
  * For the benefit of future generations (since Blst has no documentation to speak of),
  * there are two ways to pass the arrays of scalars and points into `blst_p1s_mult_pippenger()`.

--- a/src/bls12_381.h
+++ b/src/bls12_381.h
@@ -129,7 +129,7 @@ void g2_mul(g2_t *out, const g2_t *a, const fr_t *b);
 void g2_add_or_dbl(g2_t *out, const g2_t *a, const g2_t *b);
 void g2_sub(g2_t *out, const g2_t *a, const g2_t *b);
 void g2_dbl(g2_t *out, const g2_t *a);
-void g1_linear_combination(g1_t *out, const g1_t *p, const fr_t *coeffs, const uint64_t len);
+void g1_linear_combination(g1_t *out, const g1_t *p, const blst_p1_affine *g1_affine, const fr_t *coeffs, const uint64_t len);
 bool pairings_verify(const g1_t *a1, const g2_t *a2, const g1_t *b1, const g2_t *b2);
 
 #endif // BLS12_381_H

--- a/src/c_kzg.h
+++ b/src/c_kzg.h
@@ -107,6 +107,7 @@ void free_poly(poly *p);
 typedef struct {
     const FFTSettings *fs; /**< The corresponding settings for performing FFTs */
     g1_t *secret_g1;       /**< G1 group elements from the trusted setup */
+    blst_p1_affine *secret_g1_affine; /**< Affine representation of G1 group elements */
     g2_t *secret_g2;       /**< G2 group elements from the trusted setup */
     uint64_t length;       /**< The number of elements in secret_g1 and secret_g2 */
 } KZGSettings;

--- a/src/c_kzg.h
+++ b/src/c_kzg.h
@@ -105,11 +105,11 @@ void free_poly(poly *p);
  * Initialise with #new_kzg_settings. Free after use with #free_kzg_settings.
  */
 typedef struct {
-    const FFTSettings *fs; /**< The corresponding settings for performing FFTs */
-    g1_t *secret_g1;       /**< G1 group elements from the trusted setup */
+    const FFTSettings *fs;            /**< The corresponding settings for performing FFTs */
+    g1_t *secret_g1;                  /**< G1 group elements from the trusted setup */
     blst_p1_affine *secret_g1_affine; /**< Affine representation of G1 group elements */
-    g2_t *secret_g2;       /**< G2 group elements from the trusted setup */
-    uint64_t length;       /**< The number of elements in secret_g1 and secret_g2 */
+    g2_t *secret_g2;                  /**< G2 group elements from the trusted setup */
+    uint64_t length;                  /**< The number of elements in secret_g1 and secret_g2 */
 } KZGSettings;
 
 C_KZG_RET commit_to_poly(g1_t *out, const poly *p, const KZGSettings *ks);

--- a/src/c_kzg.h
+++ b/src/c_kzg.h
@@ -112,6 +112,7 @@ typedef struct {
 } KZGSettings;
 
 C_KZG_RET commit_to_poly(g1_t *out, const poly *p, const KZGSettings *ks);
+C_KZG_RET commit_to_poly_par(g1_t *out, const poly *p, const KZGSettings *ks, uint64_t parallelism);
 C_KZG_RET compute_proof_single(g1_t *out, const poly *p, const fr_t *x0, const KZGSettings *ks);
 C_KZG_RET check_proof_single(bool *out, const g1_t *commitment, const g1_t *proof, const fr_t *x, fr_t *y,
                              const KZGSettings *ks);

--- a/src/c_kzg.h
+++ b/src/c_kzg.h
@@ -114,9 +114,13 @@ typedef struct {
 C_KZG_RET commit_to_poly(g1_t *out, const poly *p, const KZGSettings *ks);
 C_KZG_RET commit_to_poly_par(g1_t *out, const poly *p, const KZGSettings *ks, uint64_t parallelism);
 C_KZG_RET compute_proof_single(g1_t *out, const poly *p, const fr_t *x0, const KZGSettings *ks);
+C_KZG_RET compute_proof_single_par(g1_t *out, const poly *p, const fr_t *x0, const KZGSettings *ks,
+                                   uint64_t parallelism);
 C_KZG_RET check_proof_single(bool *out, const g1_t *commitment, const g1_t *proof, const fr_t *x, fr_t *y,
                              const KZGSettings *ks);
 C_KZG_RET compute_proof_multi(g1_t *out, const poly *p, const fr_t *x0, uint64_t n, const KZGSettings *ks);
+C_KZG_RET compute_proof_multi_par(g1_t *out, const poly *p, const fr_t *x0, uint64_t n, const KZGSettings *ks,
+                                  uint64_t parallelism);
 C_KZG_RET check_proof_multi(bool *out, const g1_t *commitment, const g1_t *proof, const fr_t *x, const fr_t *ys,
                             uint64_t n, const KZGSettings *ks);
 C_KZG_RET new_kzg_settings(KZGSettings *ks, const g1_t *secret_g1, const g2_t *secret_g2, uint64_t length,

--- a/src/c_kzg_bench.c
+++ b/src/c_kzg_bench.c
@@ -75,10 +75,8 @@ void init_trusted_setup(FFTSettings *fs, KZGSettings *ks, int scale) {
 /*
  * Runs the benchmark for the specified time.
  *
- * @param[out] commit_time          Time to create commitment
- * @param[out] eval_time            Time to evaluate the polynomial
- * @param[out] compute_proof_time   Time to compute evaluation proof(witness)
- * @param[out] check_proof_time     Time to check the evaluation + witness
+ * @param[out] run_time             Run time stats
+ * @param[in]  data                 Polynomial eval
  * @param[in]  scale                log of polynomial length(1 more than the polynomial degree)
  * @param[in]  max_seconds          Test duration
 */

--- a/src/c_kzg_bench.c
+++ b/src/c_kzg_bench.c
@@ -138,7 +138,7 @@ void run_bench(
         assert(C_KZG_OK == new_poly(&p, fs.max_width));
         assert(C_KZG_OK == fft_fr(p.coeffs, data, true, fs.max_width, ks.fs));
         clock_gettime(CLOCK_REALTIME, &t1);
-        run_time->data_bytes += fs.max_width * sizeof(fr_t);
+        run_time->data_bytes += (fs.max_width * sizeof(fr_t));
         run_time->polynomial_len += p.length;
         run_time->interpolate_time += tdiff_usec(t0, t1);
 
@@ -216,12 +216,15 @@ int main(int argc, char *argv[]) {
     run_time_t run_time;
     run_bench(&run_time, data, 1, nsec);
     run_bench(&run_time, data, 2, nsec);
+    printf("create-witness = create-quotient + commit-quotient\n");
+    printf("Measured times in microseconds/op\n");
     for (int scale = 1; scale <= 15; scale++) {
         run_bench(&run_time, data, scale, nsec);
-        printf("data = %7lu bytes(polynomial_len = %5lu): create-polynomial = %6lu, commit = %6lu, eval = %6lu, "
-                "quotient = %6lu, create-witness = %6lu, verify = %6lu  (usec/op)\n",
+        printf("data = %7lu bytes(polynomial_len = %5lu): create-polynomial = %4lu, commit = %5lu, eval = %3lu, "
+                "create-quotient = %4lu, commit-quotient = %5lu, verify = %4lu\n",
                 run_time.data_bytes, run_time.polynomial_len,
-                run_time.interpolate_time, run_time.commit_time, run_time.eval_time,
+                run_time.interpolate_time, run_time.commit_time,
+                run_time.eval_time,
                 run_time.quotient_time, run_time.compute_proof_time,
                 run_time.check_proof_time);
     }

--- a/src/c_kzg_bench.c
+++ b/src/c_kzg_bench.c
@@ -1,0 +1,165 @@
+/*
+    Test bench.
+*/
+#include <assert.h> // assert()
+#include <stdio.h>  // printf()
+#include <stdlib.h> // malloc(), free(), atoi()
+#include <time.h>
+#include <unistd.h> // EXIT_SUCCESS/FAILURE
+#include "bench_util.h"
+#include "test_util.h"
+#include "c_kzg.h"
+
+// 32K * 32 bytes = 1 MB worth of data.
+const uint64_t MAX_FRS = 32 * 1024;
+
+/**
+ * Initializes the data with random Fr values.
+ *
+ * @param[in]  num_fr   Number of field element to initialize
+ */
+fr_t* init_data(uint64_t num_fr) {
+    fr_t *data = malloc(num_fr * sizeof(fr_t));
+    for (int i = 0; i < num_fr; i++) {
+        uint64_t a[4];
+        a[0] = rand_uint64();
+        a[1] = rand_uint64();
+        a[2] = rand_uint64();
+        a[3] = rand_uint64();
+        // Zero out the last byte of the 32 bytes, effectively making it a 31 byte entity.
+        a[3] &= 0xFFFFFF00;
+        fr_from_uint64s(&data[i], a);
+    }
+    return data;
+}
+
+
+/**
+ * Initializes the settings.
+ *
+ * @param[out] fs      Initialized FFT settings
+ * @param[out] ks      Initialized KZG settings
+ * @param[in]  scale   log of polynomial length(1 more than the polynomial degree)
+ */
+void init_trusted_setup(FFTSettings *fs, KZGSettings *ks, int scale) {
+    assert(C_KZG_OK == new_fft_settings(fs, scale));
+
+    g1_t *s1 = malloc(fs->max_width * sizeof(g1_t));
+    g2_t *s2 = malloc(fs->max_width * sizeof(g2_t));
+    generate_trusted_setup(s1, s2, &secret, fs->max_width);
+    assert(C_KZG_OK == new_kzg_settings(ks, s1, s2, fs->max_width, fs));
+}
+
+/*
+ * Runs the benchmark for the specified time.
+ *
+ * @param[out] commit_time          Time to create commitment
+ * @param[out] eval_time            Time to evaluate the polynomial
+ * @param[out] compute_proof_time   Time to compute evaluation proof(witness)
+ * @param[out] check_proof_time     Time to check the evaluation + witness
+ * @param[in]  scale                log of polynomial length(1 more than the polynomial degree)
+ * @param[in]  max_seconds          Test duration
+*/
+void run_bench(
+    long *interpolate_time,
+    long *commit_time,
+    long *eval_time,
+    long *compute_proof_time,
+    long *check_proof_time,
+    fr_t* data,
+    int scale,
+    int max_seconds
+) {
+    timespec_t start_ts, end_ts;
+    timespec_t t0, t1;
+    unsigned long total_time = 0, iter = 0;
+    FFTSettings fs;
+    KZGSettings ks;
+    g1_t commitment, proof;
+    fr_t eval_x, eval_value;
+    poly p;
+    bool result;
+
+    init_trusted_setup(&fs, &ks, scale);
+    fr_from_uint64(&eval_x, 1234);
+    while (total_time < max_seconds * NANO) {
+        iter++;
+        clock_gettime(CLOCK_REALTIME, &start_ts);
+
+        // Interpolate the polynomial from the data points.
+        clock_gettime(CLOCK_REALTIME, &t0);
+        assert(C_KZG_OK == new_poly(&p, fs.max_width));
+        assert(C_KZG_OK == fft_fr(p.coeffs, data, true, fs.max_width, ks.fs));
+        clock_gettime(CLOCK_REALTIME, &t1);
+        *interpolate_time += tdiff_usec(t0, t1);
+
+        // Create commitment
+        clock_gettime(CLOCK_REALTIME, &t0);
+        assert(C_KZG_OK == commit_to_poly(&commitment, &p, &ks));
+        clock_gettime(CLOCK_REALTIME, &t1);
+        *commit_time += tdiff_usec(t0, t1);
+
+        // Evaluate the polynomial
+        clock_gettime(CLOCK_REALTIME, &t0);
+        eval_poly(&eval_value, &p, &eval_x);
+        clock_gettime(CLOCK_REALTIME, &t1);
+        *eval_time += tdiff_usec(t0, t1);
+
+        // Create witness
+        clock_gettime(CLOCK_REALTIME, &t0);
+        assert(C_KZG_OK == compute_proof_single(&proof, &p, &eval_x, &ks));
+        clock_gettime(CLOCK_REALTIME, &t1);
+        *compute_proof_time += tdiff_usec(t0, t1);
+
+        // Check the evaluation
+        clock_gettime(CLOCK_REALTIME, &t0);
+        assert(C_KZG_OK == check_proof_single(&result, &commitment, &proof, &eval_x, &eval_value, &ks));
+        assert(result);
+        clock_gettime(CLOCK_REALTIME, &t1);
+        *check_proof_time += tdiff_usec(t0, t1);
+
+        clock_gettime(CLOCK_REALTIME, &end_ts);
+        total_time += tdiff(start_ts, end_ts);
+        free_poly(&p);
+    }
+
+    *interpolate_time /= iter;
+    *commit_time /= iter;
+    *eval_time /= iter;
+    *compute_proof_time /= iter;
+    *check_proof_time /= iter;
+
+    free_kzg_settings(&ks);
+    free_fft_settings(&fs);
+}
+
+int main(int argc, char *argv[]) {
+    int nsec = 0;
+
+    switch (argc) {
+    case 1:
+        nsec = NSEC;
+        break;
+    case 2:
+        nsec = atoi(argv[1]);
+        break;
+    default:
+        break;
+    };
+
+    if (nsec == 0) {
+        printf("Usage: %s [test time in seconds > 0]\n", argv[0]);
+        exit(EXIT_FAILURE);
+    }
+    fr_t *data = init_data(MAX_FRS);
+
+    printf("*** Benchmarking c_kzg, %d second%s per test.\n", nsec, nsec == 1 ? "" : "s");
+    long interpolate_time, commit_time, eval_time, compute_proof_time, check_proof_time;
+    run_bench(&interpolate_time, &commit_time, &compute_proof_time, &eval_time, &check_proof_time, data, 1, nsec);
+    run_bench(&interpolate_time, &commit_time, &compute_proof_time, &eval_time, &check_proof_time, data, 2, nsec);
+    for (int scale = 1; scale <= 15; scale++) {
+        run_bench(&interpolate_time, &commit_time, &compute_proof_time, &eval_time, &check_proof_time, data, scale, nsec);
+        printf("data_len = %5d: interpolate = %6lu, commitment = %6lu, eval = %6lu, compute_proof = %6lu, check_proof = %6lu  (usec/op)\n",
+                1 << scale, interpolate_time, commit_time, eval_time, compute_proof_time, check_proof_time);
+    }
+}

--- a/src/c_kzg_bench.c
+++ b/src/c_kzg_bench.c
@@ -184,8 +184,8 @@ int main(int argc, char *argv[]) {
     run_bench(&run_time, data, 2, nsec);
     for (int scale = 1; scale <= 15; scale++) {
         run_bench(&run_time, data, scale, nsec);
-        printf("data = %7lu bytes(polynomial_len = %5lu): interpolate = %6lu, commitment = %6lu, eval = %6lu, "
-                "compute_proof = %6lu, check_proof = %6lu  (usec/op)\n",
+        printf("data = %7lu bytes(polynomial_len = %5lu): create-polynomial = %6lu, commit = %6lu, eval = %6lu, "
+                "create-witness = %6lu, verify = %6lu  (usec/op)\n",
                 run_time.data_bytes, run_time.polynomial_len,
                 run_time.interpolate_time, run_time.commit_time, run_time.eval_time,
                 run_time.compute_proof_time, run_time.check_proof_time);

--- a/src/c_kzg_bench.c
+++ b/src/c_kzg_bench.c
@@ -124,7 +124,7 @@ void run_bench(
 
         // Create witness
         clock_gettime(CLOCK_REALTIME, &t0);
-        assert(C_KZG_OK == compute_proof_single(&proof, &p, &eval_x, &ks));
+        assert(C_KZG_OK == compute_proof_single_par(&proof, &p, &eval_x, &ks, 8));
         clock_gettime(CLOCK_REALTIME, &t1);
         run_time->compute_proof_time += tdiff_usec(t0, t1);
 

--- a/src/c_kzg_bench.c
+++ b/src/c_kzg_bench.c
@@ -112,7 +112,7 @@ void run_bench(
 
         // Create commitment
         clock_gettime(CLOCK_REALTIME, &t0);
-        assert(C_KZG_OK == commit_to_poly(&commitment, &p, &ks));
+        assert(C_KZG_OK == commit_to_poly_par(&commitment, &p, &ks, 8));
         clock_gettime(CLOCK_REALTIME, &t1);
         run_time->commit_time += tdiff_usec(t0, t1);
 

--- a/src/kzg_proofs.c
+++ b/src/kzg_proofs.c
@@ -30,6 +30,7 @@
 #include "c_kzg_alloc.h"
 #include "utility.h"
 
+// State passed to the threads computing the commitment
 typedef struct commit_par {
     g1_t out;
     g1_t *g1;
@@ -127,9 +128,9 @@ C_KZG_RET commit_to_poly_par(g1_t *out, const poly *p, const KZGSettings *ks, ui
 }
 
 /**
- * Thread processing to create the commitment.
+ * Commitment computation thread
  *
- * @param[in]  p  Thread args.
+ * @param[in] p Thread args.
  */
 void* g1_linear_combination_thread(void* p) {
     commit_par_t* out_par = (commit_par_t *)p;

--- a/src/kzg_proofs.c
+++ b/src/kzg_proofs.c
@@ -377,6 +377,11 @@ C_KZG_RET new_kzg_settings(KZGSettings *ks, const g1_t *secret_g1, const g2_t *s
     }
     ks->fs = fs;
 
+    // Pre-compute the g1 affine transformations
+    ks->secret_g1_affine = malloc(ks->length * sizeof(blst_p1_affine));
+    const blst_p1 *p_arg[2] = {ks->secret_g1, NULL};
+    blst_p1s_to_affine(ks->secret_g1_affine, p_arg, ks->length);
+
     return C_KZG_OK;
 }
 
@@ -388,6 +393,7 @@ C_KZG_RET new_kzg_settings(KZGSettings *ks, const g1_t *secret_g1, const g2_t *s
 void free_kzg_settings(KZGSettings *ks) {
     free(ks->secret_g1);
     free(ks->secret_g2);
+    free(ks->secret_g1_affine);
     ks->length = 0;
 }
 

--- a/src/poly.c
+++ b/src/poly.c
@@ -24,11 +24,12 @@
 #include "c_kzg_alloc.h"
 #include "utility.h"
 
+// State for the polynomial division
 typedef struct poly_div_ctx {
     // This is enabled only when divisor is of the form (x-k)
     bool fast_path_enabled;
 
-    // The Euclidean inverse of a in (x-k)
+    // The Euclidean inverse of k in (x-k)
     blst_fr k_inverse;
 } poly_div_ctx_t;
 
@@ -180,7 +181,7 @@ static C_KZG_RET poly_long_div(poly *out, const poly *dividend, const poly *divi
         a[i] = dividend->coeffs[i];
     }
 
-    // Fast path: if the divisor is a first degree polynomial of the form (x-k), the expensive
+    // Fast path for the common case: if the divisor is a first degree polynomial (x-k), the expensive
     // fr_div() can be avoided.
     if (divisor->length == 2 && fr_is_one(&divisor->coeffs[1])) {
         div_ctx.fast_path_enabled = true;


### PR DESCRIPTION
1. Precompute/cache the g1_affine format during initial set up phase. This avoids repeated g1 -> affine transformation when computing the commitments.

2. Polynomial division improvement: the polynomial division to get the quotient polynomial gets very expensive with large polynomials. This is in fact as expensive as computing the commitment to the quotient polynomial itself. Investigation revealed that the repeated modular inverse computation during fr_div() is the root cause.

    This change creates a fast path when the divisor is of the form (x-a), the common case. The division is replaced by multiplication with the precomputed inverse of a

3. Parallelism during commitment computation: the linear combination of the g1, polynomial coefficients is broken into parallel chunks and combined in the end

4. Bench to test/profile the changes